### PR TITLE
Improve metadata

### DIFF
--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -156,7 +156,12 @@ module Integrator
         end
 
         def permitted_attributes
-          (@work_klass.attribute_names + [:id, :edit_users, :edit_groups, :read_groups, :visibility]).uniq
+          (@work_klass.attribute_names + [:id, :edit_users, :edit_groups, :read_groups] + visibility_attributes).uniq
+        end
+
+        def visibility_attributes
+          %i(visibility visibility_during_embargo visibility_after_embargo embargo_release_date
+            visibility_during_lease visibility_after_lease lease_expiration_date)
         end
 
         def find_work_klass(work_id)

--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -65,7 +65,7 @@ module Integrator
           transactions["change_set.update_work"]
             .with_step_args(
               'work_resource.add_file_sets' => { uploaded_files: uploaded_files },
-              'work_resource.save_acl' => { permissions_params: [update_attributes.try('visibility') || 'open'].compact }
+              'work_resource.save_acl' => { permissions_params: [update_attributes.try('visibility')].compact }
             )
         end
       end
@@ -80,7 +80,7 @@ module Integrator
               'work_resource.add_file_sets' => { uploaded_files: uploaded_files },
               'change_set.set_user_as_depositor' => { user: @current_user },
               'work_resource.change_depositor' => { user: @current_user },
-              'work_resource.save_acl' => { permissions_params: [attrs['visibility'] || 'open'].compact }
+              'work_resource.save_acl' => { permissions_params: [attrs['visibility']].compact }
             )
         end
       end

--- a/app/controllers/concerns/willow_sword/extract_metadata.rb
+++ b/app/controllers/concerns/willow_sword/extract_metadata.rb
@@ -11,7 +11,7 @@ module WillowSword
         assign_mods_to_model
         @attributes = xw.mapped_metadata
       else
-        xw = WillowSword::DcCrosswalk.new(file_path)
+        xw = WillowSword::DcCrosswalk.new(file_path, @work_klass)
         xw.map_xml
         @attributes = xw.metadata
       end

--- a/app/controllers/concerns/willow_sword/extract_metadata.rb
+++ b/app/controllers/concerns/willow_sword/extract_metadata.rb
@@ -19,9 +19,34 @@ module WillowSword
       @resource_type = xw.model if @attributes.any?
     end
 
-    def set_visibility
-      @attributes[:visibility] ||= 'open'
-      @attributes
-    end
+    private
+
+      def set_visibility
+        # Default to open visibility
+        @attributes[:visibility] ||= 'open'
+        # If visibility is set to embargo or lease but not all fields are present, fall back to restricted
+        @attributes[:visibility] = 'restricted' unless all_embargo_fields_present? || all_lease_fields_present?
+        @attributes
+      end
+
+      def all_embargo_fields_present?
+        @attributes[:visibility] == 'embargo' && all_embargo_fields?
+      end
+
+      def all_lease_fields_present?
+        @attributes[:visibility] == 'lease' && all_lease_fields?
+      end
+
+      def all_embargo_fields?
+        @attributes[:embargo_release_date].present? &&
+          @attributes[:visibility_during_embargo].present? &&
+          @attributes[:visibility_after_embargo].present?
+      end
+
+      def all_lease_fields?
+        @attributes[:visibility_during_lease].present? &&
+          @attributes[:visibility_after_lease].present? &&
+          @attributes[:lease_expiration_date].present?
+      end
   end
 end

--- a/app/controllers/concerns/willow_sword/extract_metadata.rb
+++ b/app/controllers/concerns/willow_sword/extract_metadata.rb
@@ -14,9 +14,14 @@ module WillowSword
         xw = WillowSword::DcCrosswalk.new(file_path, @work_klass)
         xw.map_xml
         @attributes = xw.metadata
+        set_visibility
       end
       @resource_type = xw.model if @attributes.any?
     end
 
+    def set_visibility
+      @attributes[:visibility] ||= 'open'
+      @attributes
+    end
   end
 end

--- a/app/controllers/willow_sword/works_controller.rb
+++ b/app/controllers/willow_sword/works_controller.rb
@@ -51,8 +51,10 @@ module WillowSword
 
     def perform_create
       return false unless validate_and_save_request
-      return false unless parse_metadata(@metadata_file, true)
+
       set_work_klass
+      return false unless parse_metadata(@metadata_file, true)
+
       upload_files unless @files.blank?
       add_work
       true

--- a/app/views/willow_sword/file_sets/show.xml.builder
+++ b/app/views/willow_sword/file_sets/show.xml.builder
@@ -8,7 +8,7 @@ xml.feed(xmlns:"http://www.w3.org/2005/Atom",
   xml.link(rel:"edit", href:collection_work_file_set_url(params[:collection_id], params[:work_id], @file_set))
 
   # Add dc metadata
-  xw = WillowSword::DcCrosswalk.new(nil)
+  xw = WillowSword::DcCrosswalk.new(nil, @work_klass)
   @file_set.attributes.each do |attr, values|
     if xw.terms.include?(attr.to_s)
       term = xw.translated_terms.key(attr.to_s).present? ? xw.translated_terms.key(attr.to_s) : attr.to_s

--- a/app/views/willow_sword/works/show.dc.xml.builder
+++ b/app/views/willow_sword/works/show.dc.xml.builder
@@ -17,7 +17,7 @@ xml.feed(xmlns:"http://www.w3.org/2005/Atom",
     end
   end
   # Add dc metadata
-  xw = WillowSword::DcCrosswalk.new(nil)
+  xw = WillowSword::DcCrosswalk.new(nil, @work_klass)
   @object.attributes.each do |attr, values|
     if xw.terms.include?(attr.to_s)
       term = xw.translated_terms.key(attr.to_s).present? ? xw.translated_terms.key(attr.to_s) : attr.to_s

--- a/lib/willow_sword/dc_crosswalk.rb
+++ b/lib/willow_sword/dc_crosswalk.rb
@@ -30,7 +30,7 @@ module WillowSword
     end
 
     def singular
-      %w(rights)
+      %w(rights visibility)
     end
 
     def map_xml

--- a/lib/willow_sword/dc_crosswalk.rb
+++ b/lib/willow_sword/dc_crosswalk.rb
@@ -1,13 +1,15 @@
 module WillowSword
   class DcCrosswalk
-    attr_reader :metadata, :model, :terms, :translated_terms, :singular
-    def initialize(src_file)
+    attr_reader :metadata, :model, :terms, :translated_terms, :singular, :work_klass
+    def initialize(src_file, work_klass)
       @src_file = src_file
       @metadata = {}
+      @work_klass = work_klass
+      @terms = terms_for(work_klass)
     end
 
     def terms
-      %w(abstract accessRights accrualMethod accrualPeriodicity
+      @terms ||= %w(abstract accessRights accrualMethod accrualPeriodicity
         accrualPolicy alternative audience available bibliographicCitation
         conformsTo contributor coverage created creator date dateAccepted
         dateCopyrighted dateSubmitted description educationLevel extent
@@ -60,6 +62,18 @@ module WillowSword
       end
     end
 
+    private
+
+    def terms_for(work_klass)
+      return unless work_klass.present?
+
+      # Currently we have to instantiate the form off an instance of the work to get the fields to include the visibility fields.  `Work.fields` wasn't enough.
+      # TODO: Find a better way to get the fields with visibility included.
+      work_form_klass(work_klass).new(resource: work_klass.new).fields.keys
+    end
+
+    def work_form_klass(work_klass)
+      "#{work_klass}Form".constantize
+    end
   end
 end
-

--- a/lib/willow_sword/dc_crosswalk.rb
+++ b/lib/willow_sword/dc_crosswalk.rb
@@ -5,7 +5,7 @@ module WillowSword
       @src_file = src_file
       @metadata = {}
       @work_klass = work_klass
-      @terms = terms_for(work_klass)
+      @terms = terms_for(work_klass) + visibility_terms if work_klass.present?
     end
 
     def terms
@@ -30,7 +30,7 @@ module WillowSword
     end
 
     def singular
-      %w(rights visibility)
+      %w(rights visibility) + visibility_terms
     end
 
     def map_xml
@@ -60,6 +60,11 @@ module WillowSword
           |t| t.underscore.gsub('_', ' ').gsub('-', ' ').downcase
         }.first
       end
+    end
+
+    def visibility_terms
+      %w(visibility_during_embargo visibility_after_embargo embargo_release_date
+        visibility_during_lease visibility_after_lease lease_expiration_date)
     end
 
     private

--- a/spec/lib/willow_sword/dc_crosswalk_spec.rb
+++ b/spec/lib/willow_sword/dc_crosswalk_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe WillowSword::DcCrosswalk do
   describe 'DcCrosswalk with no source' do
     before(:each) do
       @src = nil
+      @work_klass = nil
       # @no_src = File.join(ENGINE_RAILS_ROOT, 'spec', 'fixtures', 'dc2.xml')
-      @dc = WillowSword::DcCrosswalk.new(@src)
+      @dc = WillowSword::DcCrosswalk.new(@src, @work_klass)
     end
 
     it "should have the dublin core terms" do
@@ -39,8 +40,9 @@ RSpec.describe WillowSword::DcCrosswalk do
   describe 'DcCrosswalk with valid source' do
     before(:each) do
       @src = File.join(ENGINE_RAILS_ROOT, 'spec', 'fixtures', 'dc.xml')
+      @work_klass = nil
       # @no_src = File.join(ENGINE_RAILS_ROOT, 'spec', 'fixtures', 'dc2.xml')
-      @dc = WillowSword::DcCrosswalk.new(@src)
+      @dc = WillowSword::DcCrosswalk.new(@src, @work_klass)
     end
 
     it 'should return a valid crosswalk' do
@@ -66,7 +68,8 @@ RSpec.describe WillowSword::DcCrosswalk do
   describe 'DcCrosswalk with invalid source' do
     before(:each) do
       no_src = File.join(ENGINE_RAILS_ROOT, 'spec', 'fixtures', 'dc2.xml')
-      @dc = WillowSword::DcCrosswalk.new(no_src)
+      work_klass = nil
+      @dc = WillowSword::DcCrosswalk.new(no_src, work_klass)
     end
 
     it 'should return a empty crosswalk' do
@@ -79,7 +82,8 @@ RSpec.describe WillowSword::DcCrosswalk do
   describe 'DcCrosswalk with non xml source' do
     before(:each) do
       src = File.join(ENGINE_RAILS_ROOT, 'spec', 'fixtures', 'testPackage', 'Swordv2Spec.pdf')
-      @dc = WillowSword::DcCrosswalk.new(src)
+      work_klass = nil
+      @dc = WillowSword::DcCrosswalk.new(src, work_klass)
     end
 
     it 'should return a empty crosswalk' do


### PR DESCRIPTION
## 🎁 Derive metadata terms from work

ece3f4901b266074945b92d6461b2fb87b53bcc3

Previously we were very strict with handling only Dublin Core terms.
This approach allows our xml to be more flexible and mapp any term we
want to the metadata which is derived from the work itself.

## 🐛 Fix visibility fallback to open

db7400d372d57fb73a9d0b6d7c0d590e64c7e1fa

Previously, the visibility always came in as restricted and now it
should fallback to open.

## 🎁 Add more visibility attributes

5bc8c3c98a9f477e758ea4c5e65da184fcd52ae6

We now are able to set the visbility embargo/lease information for a
work.  A sample xml file would be:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<metadata>
  <title>Test record</title>
  <creator>User, Some</creator>
  <subject>Sword</subject>
  <subject>Crosswalk</subject>
  <description>This is a test dc record to test the dc crosswalk</description>
  <publisher>Digital Nest</publisher>
  <contributor>The dublin core generator</contributor>
  <created>29/05/2018</created>
  <source>http://sword.digitalnest.com</source>
  <language>English</language>
  <rights_statement>http://rightsstatements.org/vocab/InC/1.0/</rights_statement>
  <resource_type>Article</resource_type>
  <keyword>Test</keyword>
  <keyword>Another</keyword>
  <visibility>lease</visibility>
  <visibility_during_lease>authenticated</visibility_during_lease>
  <lease_expiration_date>2024-05-31</lease_expiration_date>
  <visibility_after_lease>restricted</visibility_after_lease>
</metadata>
```
