### PR TITLE
🐛 Fix service document to returns collections

### DIFF
--- a/app/controllers/concerns/integrator/hyrax/service_documents_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/service_documents_behavior.rb
@@ -3,7 +3,8 @@ module Integrator
     module ServiceDocumentsBehavior
       extend ActiveSupport::Concern
       def show
-        @collections = Collection.all
+        ids = ::Hyrax::Collections::PermissionsService.collection_ids_for_view(ability: current_ability)
+        @collections = ::Hyrax.query_service.find_many_by_ids(ids: ids)
         if @collections.blank?
           @collections = [Collection.new(WillowSword.config.default_collection)]
         end


### PR DESCRIPTION
Prior to this commit, the service document was only returning the default collection because it was calling the Active Fedora Collection. This commit will check the user's permissions and return the Valyrie Collection.

A user with a viewable collection:
```sh
curl --request GET \
  --url http://dev.hyku.test/sword/service_document \
  --header "Content-Type: application/xml" \
  --header "Api-key: a-user-key"

<service xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:sword="http://purl.org/net/sword/terms/" xmlns="http://www.w3.org/2007/app">
  <sword:version>2.0</sword:version>
  <workspace collections="1">
    <atom:title>Hyrax Sword V2 server</atom:title>
    <collection href="http://dev.hyku.test/sword/collections/be83f0ab-f9ec-4c65-a78f-16c97e894246">
      <atom:title>Test Collection</atom:title>
      <accept>*/*</accept>
      <accept alternate="multipart-related">
*/*      </accept>
      <sword:collectionPolicy>TODO: Collection Policy</sword:collectionPolicy>
      <dcterms:abstract></dcterms:abstract>
      <sword:mediation>true</sword:mediation>
      <sword:treatment>TODO: Treatment description</sword:treatment>
      <sword:acceptPackaging>http://purl.org/net/sword/package/SimpleZip</sword:acceptPackaging>
      <sword:acceptPackaging>http://purl.org/net/sword/package/BagIt</sword:acceptPackaging>
      <sword:acceptPackaging>http://purl.org/net/sword/package/Binary</sword:acceptPackaging>
    </collection>
  </workspace>
</service>
```

A viewer with no visible collections:
```sh
curl --request GET \
  --url http://dev.hyku.test/sword/service_document \
  --header "Content-Type: application/xml" \
  --header "Api-key: another-user-key"

<service xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:sword="http://purl.org/net/sword/terms/" xmlns="http://www.w3.org/2007/app">
  <sword:version>2.0</sword:version>
  <workspace collections="1">
    <atom:title>Hyrax Sword V2 server</atom:title>
    <collection href="http://dev.hyku.test/sword/collections/default">
      <atom:title>Default collection</atom:title>
      <accept>*/*</accept>
      <accept alternate="multipart-related">
*/*      </accept>
      <sword:collectionPolicy>TODO: Collection Policy</sword:collectionPolicy>
      <dcterms:abstract></dcterms:abstract>
      <sword:mediation>true</sword:mediation>
      <sword:treatment>TODO: Treatment description</sword:treatment>
      <sword:acceptPackaging>http://purl.org/net/sword/package/SimpleZip</sword:acceptPackaging>
      <sword:acceptPackaging>http://purl.org/net/sword/package/BagIt</sword:acceptPackaging>
      <sword:acceptPackaging>http://purl.org/net/sword/package/Binary</sword:acceptPackaging>
    </collection>
  </workspace>
</service>
```