### PR TITLE
🐛 Remove ActiveFedora collections from query

### DIFF
--- a/app/controllers/concerns/integrator/hyrax/service_documents_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/service_documents_behavior.rb
@@ -4,7 +4,7 @@ module Integrator
       extend ActiveSupport::Concern
       def show
         ids = ::Hyrax::Collections::PermissionsService.collection_ids_for_view(ability: current_ability)
-        @collections = ::Hyrax.query_service.find_many_by_ids(ids: ids)
+        @collections = ::Hyrax.query_service.find_many_by_ids(ids: ids).reject { |c| c.singleton_class.to_s.nil? }
         if @collections.blank?
           @collections = [Collection.new(WillowSword.config.default_collection)]
         end


### PR DESCRIPTION
This commit will add a reject for any ActiveFedora collections.  We were seeing the issue that collections that have been migrated would show up twice, once the Valkyrie resource and a second time as the one that is found in ActiveFedora.