### PR TITLE
🎁 Support admin sets in service document

### DIFF
--- a/app/controllers/concerns/integrator/hyrax/service_documents_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/service_documents_behavior.rb
@@ -3,11 +3,22 @@ module Integrator
     module ServiceDocumentsBehavior
       extend ActiveSupport::Concern
       def show
-        ids = ::Hyrax::Collections::PermissionsService.collection_ids_for_view(ability: current_ability)
+        ids = collection_ids + admin_set_ids
         @collections = ::Hyrax.query_service.find_many_by_ids(ids: ids).reject { |c| c.singleton_class.to_s.nil? }
+        @collections = @collections&.sort_by(&:internal_resource)
         if @collections.blank?
           @collections = [Collection.new(WillowSword.config.default_collection)]
         end
+      end
+
+      private
+
+      def collection_ids
+        ::Hyrax::Collections::PermissionsService.collection_ids_for_view(ability: current_ability)
+      end
+
+      def admin_set_ids
+        ::Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set')
       end
     end
   end

--- a/app/views/willow_sword/service_documents/show.xml.builder
+++ b/app/views/willow_sword/service_documents/show.xml.builder
@@ -5,11 +5,12 @@ xml.service('xmlns:atom':"http://www.w3.org/2005/Atom", 'xmlns:dcterms':"http://
     xml.atom :title, WillowSword.config.title
     @collections.each do |collection|
       xml.collection(href: collection_url(collection.id)) do
-        xml.atom :title, collection.title.join(", ")
+        xml.atom :title, Array.wrap(collection.title).join(", ")
+        xml.type collection.internal_resource
         xml.accept "*/*"
         xml.accept(alternate:"multipart-related") do xml.text! "*/*" end
         xml.sword :collectionPolicy, "TODO: Collection Policy"
-        xml.dcterms :abstract, collection.description.join(", ")
+        xml.dcterms :abstract, Array.wrap(collection.description).join(", ")
         xml.sword :mediation, "true"
         xml.sword :treatment, "TODO: Treatment description"
         xml.sword :acceptPackaging, "http://purl.org/net/sword/package/SimpleZip"


### PR DESCRIPTION
This commit will support the retrieval of admin sets when pulling the service document.  This will help the user determine what admin set to deposit to.