### PR TITLE
🎁 Add more robust metadata for file sets

### DIFF
--- a/app/views/willow_sword/file_sets/show.xml.builder
+++ b/app/views/willow_sword/file_sets/show.xml.builder
@@ -1,19 +1,67 @@
-xml.feed(xmlns:"http://www.w3.org/2005/Atom",
-  'xmlns:dcterms':"http://purl.org/dc/terms/",
-  'xmlns:dc':"http://purl.org/dc/elements/1.1/") do
-  Array(@file_set.title).each do |t|
-    xml.title t
-  end
-  xml.content(rel:"src", href:collection_work_file_set_url(params[:collection_id], params[:work_id], @file_set))
-  xml.link(rel:"edit", href:collection_work_file_set_url(params[:collection_id], params[:work_id], @file_set))
+if WillowSword.config.xml_mapping_read == 'Hyku'
+  # This use of HykuCrosswalk is very similar to the works/show.hyku.xml.builder
+  # however I couldn't figure out a way in the builder to render that one.  It would be
+  # Nice if we can just use the one builder in the future.
+  xw = WillowSword::HykuCrosswalk.new(@file_set)
+  xml.feed(xw.namespaces) do
+    xml.title @file_set.title.join(", ")
+    # Get work
+    xml.content(rel:"src", href:collection_work_url(params[:collection_id], @file_set))
+    # Add file to work
+    xml.link(rel:"edit", href:collection_work_file_sets_url(params[:collection_id], @file_set))
 
-  # Add dc metadata
-  xw = WillowSword::DcCrosswalk.new(nil, @work_klass)
-  @file_set.attributes.each do |attr, values|
-    if xw.terms.include?(attr.to_s)
-      term = xw.translated_terms.key(attr.to_s).present? ? xw.translated_terms.key(attr.to_s) : attr.to_s
-      Array(values).each do |val|
-        xml.dc term.to_sym, val
+    # Add h4csys, mainly system generated metadata
+    xw.system_terms.each do |term|
+      Array.wrap(@file_set.send(term)).each do |val|
+        val = val.to_s
+        next if val.blank?
+
+        prefix = xw.prefix_lookup_for('h4csys')
+        xml.tag!(:"#{prefix}:#{term}", val)
+      end
+    end
+
+    # Add h4cmeta, settable metadata
+    xw.terms.each do |term|
+      Array.wrap(@file_set.send(term)).each do |val|
+        val = val.to_s
+        next if val.blank?
+
+        prefix = xw.prefix_lookup_for('h4cmeta')
+        xml.tag!(:"#{prefix}:#{term}", val)
+      end
+    end
+
+    # Add dc and dcterms
+    xw.dc_terms.each do |term|
+      Array.wrap(@file_set.send(term)).each do |val|
+        val = val.to_s
+        next if val.blank?
+
+        prefix = xw.dc_terms_to_fallback_to_dc.include?(term) ? 'dc' : xw.prefix_lookup_for(term)
+        translated_term = xw.term_translation_mappings[term] || term
+        xml.tag!(:"#{prefix}:#{translated_term}", val)
+      end
+    end
+  end
+else
+  xml.feed(xmlns:"http://www.w3.org/2005/Atom",
+    'xmlns:dcterms':"http://purl.org/dc/terms/",
+    'xmlns:dc':"http://purl.org/dc/elements/1.1/") do
+    Array(@file_set.title).each do |t|
+      xml.title t
+    end
+    xml.content(rel:"src", href:collection_work_file_set_url(params[:collection_id], params[:work_id], @file_set))
+    xml.link(rel:"edit", href:collection_work_file_set_url(params[:collection_id], params[:work_id], @file_set))
+
+    # Add dc metadata
+    xw = WillowSword::DcCrosswalk.new(nil, @work_klass)
+    @file_set.attributes.each do |attr, values|
+      if xw.terms.include?(attr.to_s)
+        term = xw.translated_terms.key(attr.to_s).present? ? xw.translated_terms.key(attr.to_s) : attr.to_s
+        Array(values).each do |val|
+          xml.dc term.to_sym, val
+        end
       end
     end
   end

--- a/lib/willow_sword/hyku_crosswalk.rb
+++ b/lib/willow_sword/hyku_crosswalk.rb
@@ -37,7 +37,7 @@ module WillowSword
     def system_terms
       %w(id internal_resource created_at
          updated_at new_record date_modified
-         date_uploaded depositor state)
+         date_uploaded depositor state).select { |term| work.respond_to?(term) }
     end
 
     # @returns [Array<String>] a list of Dublin Core terms used in the work


### PR DESCRIPTION
This commit will give a similar treat to the file sets as we did for the works.  The metadata builder is primarily built off of the works hyku xml builder however I couldn't figure out a way just to render that instead.  That would be a nice future investigation to consolidate the two builders.

```xml
<feed dc="http://purl.org/dc/elements/1.1/" dcterms="http://purl.org/dc/terms/" h4cmeta="https://hykucommons.org/schema/metadata" h4csys="https://hykucommons.org/schema/system">
  <title>DissertationImage.jpg</title>
  <content rel="src" href="http://dev.hyku.test/sword/collections/default/works/84e2d2e4-9a84-4990-8acb-4c396dfbb066"/>
  <link rel="edit" href="http://dev.hyku.test/sword/collections/default/works/84e2d2e4-9a84-4990-8acb-4c396dfbb066/file_sets"/>
  <h4csys:id>84e2d2e4-9a84-4990-8acb-4c396dfbb066</h4csys:id>
  <h4csys:internal_resource>FileSet</h4csys:internal_resource>
  <h4csys:created_at>2025-02-20 22:56:42 UTC</h4csys:created_at>
  <h4csys:updated_at>2025-02-20 23:04:19 UTC</h4csys:updated_at>
  <h4csys:new_record>false</h4csys:new_record>
  <h4csys:date_modified>2025-02-20T22:56:42+00:00</h4csys:date_modified>
  <h4csys:date_uploaded>2025-02-20T22:56:40+00:00</h4csys:date_uploaded>
  <h4csys:depositor>admin@example.com</h4csys:depositor>
  <h4cmeta:embargo_id>10b2165b-35d0-4064-abc7-a474df8227a3</h4cmeta:embargo_id>
  <h4cmeta:title>DissertationImage.jpg</h4cmeta:title>
  <h4cmeta:creator>admin@example.com</h4cmeta:creator>
  <h4cmeta:label>DissertationImage.jpg</h4cmeta:label>
  <h4cmeta:file_ids>fe74e81e-04ca-42ce-a95e-d6f9d3bf3bcd</h4cmeta:file_ids>
  <h4cmeta:file_ids>7c373fa5-3383-4b50-a40a-59ce989348eb</h4cmeta:file_ids>
  <h4cmeta:file_ids>351c2514-9e5f-4730-8fc3-5a24aafc742b</h4cmeta:file_ids>
  <h4cmeta:file_ids>a941cac0-abf4-495c-9a6a-0c2198400210</h4cmeta:file_ids>
  <h4cmeta:visibility_during_embargo>restricted</h4cmeta:visibility_during_embargo>
  <h4cmeta:visibility_after_embargo>open</h4cmeta:visibility_after_embargo>
  <h4cmeta:embargo_release_date>2025-03-07T00:00:00+00:00</h4cmeta:embargo_release_date>
  <dc:title>DissertationImage.jpg</dc:title>
  <dc:creator>admin@example.com</dc:creator>
  <dcterms:modified>2025-02-20T22:56:42+00:00</dcterms:modified>
  <dcterms:dateSubmitted>2025-02-20T22:56:40+00:00</dcterms:dateSubmitted>
</feed>
```
Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/419
