### PR TITLE
🧹 Use SolrDocument instead of Valkyrie resource

### DIFF
--- a/app/views/willow_sword/service_documents/show.xml.builder
+++ b/app/views/willow_sword/service_documents/show.xml.builder
@@ -6,7 +6,7 @@ xml.service('xmlns:atom':"http://www.w3.org/2005/Atom", 'xmlns:dcterms':"http://
     @collections.each do |collection|
       xml.collection(href: collection_url(collection.id)) do
         xml.atom :title, Array.wrap(collection.title).join(", ")
-        xml.type collection.internal_resource
+        xml.type collection['has_model_ssim'].first
         xml.accept "*/*"
         xml.accept(alternate:"multipart-related") do xml.text! "*/*" end
         xml.sword :collectionPolicy, "TODO: Collection Policy"


### PR DESCRIPTION
This commit will change the service document query to use the SolrDocument version instead of the Valkyrie Resource because the `Hyrax.query_service.find_by_many_ids` call go through ActiveFedora and is so slow it times out.  Instead, we will use the SolrDocument which is much faster.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/283