### PR TITLE
🐛 Fix namespace declarations

### DIFF
--- a/app/views/willow_sword/file_sets/show.xml.builder
+++ b/app/views/willow_sword/file_sets/show.xml.builder
@@ -3,7 +3,7 @@ if WillowSword.config.xml_mapping_read == 'Hyku'
   # however I couldn't figure out a way in the builder to render that one.  It would be
   # Nice if we can just use the one builder in the future.
   xw = WillowSword::HykuCrosswalk.new(@file_set)
-  xml.feed(xw.namespaces) do
+  xml.feed(xw.namespace_declarations) do
     xml.title @file_set.title.join(", ")
     # Get work
     xml.content(rel:"src", href:collection_work_url(params[:collection_id], @file_set))

--- a/app/views/willow_sword/works/show.hyku.xml.builder
+++ b/app/views/willow_sword/works/show.hyku.xml.builder
@@ -1,5 +1,5 @@
 xw = WillowSword::HykuCrosswalk.new(@object)
-xml.feed(xw.namespaces) do
+xml.feed(xw.namespace_declarations) do
   xml.title @object.title.join(", ")
   # Get work
   xml.content(rel:"src", href:collection_work_url(params[:collection_id], @object))

--- a/lib/willow_sword/hyku_crosswalk.rb
+++ b/lib/willow_sword/hyku_crosswalk.rb
@@ -8,7 +8,15 @@ module WillowSword
       @terms = terms
     end
 
-    # @returns [Hash] a hash of namespaces used in the work
+    # @returns [Hash] a hash of namespace declarations used in the work
+    def namespace_declarations
+      default_namespace.merge(namespaces.transform_keys { |key| "xmlns:#{key}" })
+    end
+
+    def default_namespace
+      { 'xmlns' => 'http://www.w3.org/2005/Atom' }
+    end
+
     def namespaces
       {
         'dc' => 'http://purl.org/dc/elements/1.1/',

--- a/spec/views/willow_sword/works/show.hyku.xml.builder_spec.rb
+++ b/spec/views/willow_sword/works/show.hyku.xml.builder_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'willow_sword/works/show.hyku.xml.builder', type: :view do
     actual_doc = Nokogiri::XML(rendered)
     expected_doc = Nokogiri::XML(<<~XML)
       <?xml version="1.0"?>
-      <feed dc="http://purl.org/dc/elements/1.1/" dcterms="http://purl.org/dc/terms/" h4cmeta="https://hykucommons.org/schema/metadata" h4csys="https://hykucommons.org/schema/system">
+      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:h4cmeta="https://hykucommons.org/schema/metadata" xmlns:h4csys="https://hykucommons.org/schema/system">
         <title>Test Title</title>
         <content rel="src" href="http://example.com/collections/col123/works/123"/>
         <link rel="edit" href="http://example.com/collections/col123/works/123/file_sets"/>


### PR DESCRIPTION
This commit will fix the namespace declarations to be well formed.

```xml
<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:h4cmeta="https://hykucommons.org/schema/metadata" xmlns:h4csys="[https://hykucommons.org/schema/system">`](https://hykucommons.org/schema/system%22%3E%60)
```

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/289