### PR TITLE
I292 work deposit errors

### DIFF
--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -77,7 +77,7 @@ module Integrator
 
         @object = @work_klass.new
 
-        perform_transaction_for(object: @object, attrs: attrs) do
+        @object = perform_transaction_for(object: @object, attrs: attrs) do
           transactions['change_set.create_work']
             .with_step_args(
               'work_resource.add_file_sets' => { uploaded_files: uploaded_files },

--- a/app/controllers/willow_sword/works_controller.rb
+++ b/app/controllers/willow_sword/works_controller.rb
@@ -26,12 +26,14 @@ module WillowSword
 
     def create
       @error = nil
-      if perform_create
+
+      begin
+        perform_create
         @file_set_ids = file_set_ids
         # @collection_id = params[:collection_id]
         render 'create.xml.builder', formats: [:xml], status: :created, location: collection_work_url(params[:collection_id], @object)
-      else
-        @error = WillowSword::Error.new("Error creating work") unless @error.present?
+      rescue StandardError => e
+        @error = WillowSword::Error.new(e.message) unless @error.present?
         render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
       end
     end
@@ -41,10 +43,12 @@ module WillowSword
       find_work_by_query
       render_not_found and return unless @object
       @error = nil
-      if perform_update
+
+      begin
+        perform_update
         render 'update.xml.builder', formats: [:xml], status: :ok
-      else
-        @error = WillowSword::Error.new("Error updating work") unless @error.present?
+      rescue StandardError => e
+        @error = WillowSword::Error.new(e.message) unless @error.present?
         render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
       end
     end
@@ -52,22 +56,18 @@ module WillowSword
     private
 
     def perform_create
-      return false unless validate_and_save_request
-
+      validate_and_save_request || raise("Request validation failed")
       set_work_klass
-      return false unless parse_metadata(@metadata_file, true)
-
+      parse_metadata(@metadata_file, true) || raise("Metadata parsing failed")
       upload_files unless @files.blank?
       add_work
-      true
     end
 
     def perform_update
-      return false unless validate_and_save_request
-      return false unless parse_metadata(@metadata_file, false)
+      validate_and_save_request || raise("Request validation failed")
+      parse_metadata(@metadata_file, false) || raise("Metadata parsing failed")
       upload_files unless @files.blank?
       add_work
-      true
     end
 
     def render_not_found


### PR DESCRIPTION
## 🎁 Allow admin_set_id to be passed in through URL

77c8455c1cbab809638cc52353ff19a108eeb13a

This commit will let the admin_set_id be passed in through the URL.  The
user can use the collection id to pass in the admin_set_id that they
want to deposit the work into.  If the id is not a valid admin set then
it will fall back to the default admin set.

Also, we want to priortize the Valkyrie resource version of the work so
if the user passes in `--header 'Hyrax-Work-Model: Etd' \` in the
headers, then it will still create an EtdResource.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/292

## 🐛 Fix work id not populating XML

eeefdd41dc6d0bf62f30f4ab3c8573edff8fd428

This commit will make sure that `@object` is set to the newly created
work instead of the new work that doesn't have the id.

```xml
<feed xmlns="http://www.w3.org/2005/Atom">
  <title>Molecular Mechanisms Controlling Immunity, Fertility, and Longevity</title>
  <content rel="src" href="https://dev.hyku.test/sword/collections/e01455cb-9877-4c28-aa1c-012caa000642/works/ddb7aef4-ef23-4cdb-a777-78d3f35126d9"/>
  <link rel="edit" href="https://dev.hyku.test/sword/collections/e01455cb-9877-4c28-aa1c-012caa000642/works/ddb7aef4-ef23-4cdb-a777-78d3f35126d9/file_sets"/>
  <entry>
    <content rel="src" href="https://dev.hyku.test/sword/collections/e01455cb-9877-4c28-aa1c-012caa000642/works/ddb7aef4-ef23-4cdb-a777-78d3f35126d9/file_sets/c7426a7f-def1-481d-abf3-dcd54b5c9ef2"/>
    <link rel="edit" href="https://dev.hyku.test/sword/collections/e01455cb-9877-4c28-aa1c-012caa000642/works/ddb7aef4-ef23-4cdb-a777-78d3f35126d9/file_sets/c7426a7f-def1-481d-abf3-dcd54b5c9ef2"/>
  </entry>
  <entry>
    <content rel="src" href="https://dev.hyku.test/sword/collections/e01455cb-9877-4c28-aa1c-012caa000642/works/ddb7aef4-ef23-4cdb-a777-78d3f35126d9/file_sets/1868f3a7-a113-46bf-b0c7-3ae482b6fc78"/>
    <link rel="edit" href="https://dev.hyku.test/sword/collections/e01455cb-9877-4c28-aa1c-012caa000642/works/ddb7aef4-ef23-4cdb-a777-78d3f35126d9/file_sets/1868f3a7-a113-46bf-b0c7-3ae482b6fc78"/>
  </entry>
  <entry>
    <content rel="src" href="https://dev.hyku.test/sword/collections/e01455cb-9877-4c28-aa1c-012caa000642/works/ddb7aef4-ef23-4cdb-a777-78d3f35126d9/file_sets/44741135-e46c-479e-976c-e9a2819528ca"/>
    <link rel="edit" href="https://dev.hyku.test/sword/collections/e01455cb-9877-4c28-aa1c-012caa000642/works/ddb7aef4-ef23-4cdb-a777-78d3f35126d9/file_sets/44741135-e46c-479e-976c-e9a2819528ca"/>
  </entry>
  <entry>
    <content rel="src" href="https://dev.hyku.test/sword/collections/e01455cb-9877-4c28-aa1c-012caa000642/works/ddb7aef4-ef23-4cdb-a777-78d3f35126d9/file_sets/be6eb2b4-c523-4cdd-89b9-ed369da70427"/>
    <link rel="edit" href="https://dev.hyku.test/sword/collections/e01455cb-9877-4c28-aa1c-012caa000642/works/ddb7aef4-ef23-4cdb-a777-78d3f35126d9/file_sets/be6eb2b4-c523-4cdd-89b9-ed369da70427"/>
  </entry>
</feed>
```

## 🎁 Catch more errors

4da15046b67e623d28403ed83fb19aac850b1e49

This commit makes it nicer for users to understand the error message
that is given if they are getting errors from the Hyrax transactions
such as missing required fields.

```xml
<sword:error xmlns:sword="http://purl.org/net/sword/" xmlns:arxiv="http://arxiv.org/schemas/atom" xmlns="http://www.w3.org/2005/Atom" href="http://purl.org/net/sword/error/ErrorBadRequest">
  <author>
    <name>Sword v2 server</name>
  </author>
  <title>ERROR</title>
  <updated>2025-03-25T03:24:06Z</updated>
  <generator uri="https://example.org/sword-app/" version="0.1">
sword@example.org  </generator>
  <summary>failed_validation - Rights statement can't be blank,Degree discipline can't be blank,Degree grantor can't be blank</summary>
  <sword:treatment>processing failed</sword:treatment>
```
