### PR TITLE
🐛 Remove atom:title tag from update response

### DIFF
--- a/app/views/willow_sword/works/update.xml.builder
+++ b/app/views/willow_sword/works/update.xml.builder
@@ -1,7 +1,6 @@
 xml.feed(xmlns: "http://www.w3.org/2005/Atom") do
   xml.title "Update Success"
   xml.updated Time.now.iso8601
-  xml.atom :title, WillowSword.config.title
   xml.link(rel: "self", href: collection_work_url(params[:collection_id], @object))
   xml.entry do
     xml.id @object.id


### PR DESCRIPTION
Thie atom:title tag is incorrect and needed to be removed from the update response.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/289