### PR TITLE
🐛 Fallback to default work model

### DIFF
--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -118,8 +118,8 @@ module Integrator
             # Set the class based on the resource type
             @work_klass = work_models[@resource_type].constantize
           else
-            # Chooose the first class from the config
-            @work_klass = work_models[work_models.keys.first].constantize
+            # Fallback to default work model
+            @work_klass = WillowSword.config.default_work_model
           end
         end
 


### PR DESCRIPTION
When all condition checks fail to find the work_klass, we should fallback to the default work model that is set.