### PR TITLE
Rework visibility again to remove requirement

### DIFF
--- a/app/controllers/concerns/willow_sword/extract_metadata.rb
+++ b/app/controllers/concerns/willow_sword/extract_metadata.rb
@@ -23,7 +23,7 @@ module WillowSword
 
       def set_visibility
         @attributes[:visibility]&.strip!
-        raise "Visibility required" if @attributes[:visibility].blank?
+        return @attributes[:visibility] = 'restricted' if @attributes[:visibility].blank?
 
         case @attributes[:visibility]
         when 'authenticated', 'open', 'restricted'


### PR DESCRIPTION
This commit will remove the requirement for visibility.  If no visibility is set, it will default to private/restricted instead of raising an error.