### PR TITLE
Fix the file set show content and link tags

### DIFF
--- a/app/views/willow_sword/file_sets/show.xml.builder
+++ b/app/views/willow_sword/file_sets/show.xml.builder
@@ -5,10 +5,8 @@ if WillowSword.config.xml_mapping_read == 'Hyku'
   xw = WillowSword::HykuCrosswalk.new(@file_set)
   xml.feed(xw.namespace_declarations) do
     xml.title @file_set.title.join(", ")
-    # Get work
-    xml.content(rel:"src", href:collection_work_url(params[:collection_id], @file_set))
-    # Add file to work
-    xml.link(rel:"edit", href:collection_work_file_sets_url(params[:collection_id], @file_set))
+    xml.content(rel:"src", href:collection_work_file_set_url(params[:collection_id], params[:work_id], @file_set))
+    xml.link(rel:"edit", href:collection_work_file_set_url(params[:collection_id], params[:work_id], @file_set))
 
     # Add h4csys, mainly system generated metadata
     xw.system_terms.each do |term|


### PR DESCRIPTION
This commit will fix the URL of the content and link tags for a file set show response.  The ids were incorrect.

Example:
```sh
curl --request GET \
  --url https://dev-hyku.localhost.direct/sword/collections/default/works/f9e17d86-51ef-4122-ab18-a5257b622cce/file_sets/5f2bc8f4-1f7e-4eb1-b817-153e29ee60c4 \
  --header 'Api-key: <some-key>'
```

Sample feed response:
```xml
<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:h4cmeta="https://hykucommons.org/schema/metadata" xmlns:h4csys="https://hykucommons.org/schema/system">
  <title>test_doc.docx</title>
  <content rel="src" href="https://dev-hyku.localhost.direct/sword/collections/default/works/f9e17d86-51ef-4122-ab18-a5257b622cce/file_sets/5f2bc8f4-1f7e-4eb1-b817-153e29ee60c4"/>
  <link rel="edit" href="https://dev-hyku.localhost.direct/sword/collections/default/works/f9e17d86-51ef-4122-ab18-a5257b622cce/file_sets/5f2bc8f4-1f7e-4eb1-b817-153e29ee60c4"/>
  <h4csys:id>5f2bc8f4-1f7e-4eb1-b817-153e29ee60c4</h4csys:id>
  <h4csys:internal_resource>FileSet</h4csys:internal_resource>
  <h4csys:created_at>2025-04-10 18:58:23 UTC</h4csys:created_at>
  <h4csys:updated_at>2025-04-10 18:58:25 UTC</h4csys:updated_at>
  <h4csys:new_record>false</h4csys:new_record>
  <h4csys:date_modified>2025-04-10T18:58:23+00:00</h4csys:date_modified>
  <h4csys:date_uploaded>2025-04-10T18:55:57+00:00</h4csys:date_uploaded>
  <h4csys:depositor>admin@example.com</h4csys:depositor>
  <h4cmeta:schema_version>1</h4cmeta:schema_version>
  <h4cmeta:title>test_doc.docx</h4cmeta:title>
  <h4cmeta:creator>admin@example.com</h4cmeta:creator>
  <h4cmeta:label>test_doc.docx</h4cmeta:label>
  <h4cmeta:file_ids>87f94f63-8136-4a5b-a4b9-c0c024453313</h4cmeta:file_ids>
  <dc:title>test_doc.docx</dc:title>
  <dc:creator>admin@example.com</dc:creator>
  <dcterms:modified>2025-04-10T18:58:23+00:00</dcterms:modified>
  <dcterms:dateSubmitted>2025-04-10T18:55:57+00:00</dcterms:dateSubmitted>
</feed>
```