### PR TITLE
Change CollectionsBehavior show to use solr doc

### DIFF
--- a/app/views/willow_sword/collections/show.xml.builder
+++ b/app/views/willow_sword/collections/show.xml.builder
@@ -1,6 +1,6 @@
 xml.feed(xmlns:"http://www.w3.org/2005/Atom") do
   xml.title @collection.title.join(", ")
-  xml.type @collection.internal_resource
+  xml.type @collection['has_model_ssim'].first
   xml.link(rel:"edit", href:collection_works_url(@collection.id))
   @works.each do |work|
     xml.entry do


### PR DESCRIPTION
This commit will change the CollectionsBehavior show action to use the solr document instead of the record for faster responses.