### PR TITLE
Simplify endpoint structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.rbc
 capybara-*.html
-.rspec
 /log
 /tmp
 /db/*.sqlite3

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require rails_helper

--- a/app/controllers/willow_sword/v2/collections_controller.rb
+++ b/app/controllers/willow_sword/v2/collections_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module WillowSword
+  module V2
+    class CollectionsController < WillowSword::CollectionsController
+    end
+  end
+end

--- a/app/controllers/willow_sword/v2/file_sets_controller.rb
+++ b/app/controllers/willow_sword/v2/file_sets_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module WillowSword
+  module V2
+    class FileSetsController < WillowSword::FileSetsController
+    end
+  end
+end

--- a/app/controllers/willow_sword/v2/service_documents_controller.rb
+++ b/app/controllers/willow_sword/v2/service_documents_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module WillowSword
+  module V2
+    class ServiceDocumentsController < WillowSword::ServiceDocumentsController
+    end
+  end
+end

--- a/app/controllers/willow_sword/v2/works_controller.rb
+++ b/app/controllers/willow_sword/v2/works_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module WillowSword
+  module V2
+    class WorksController < WillowSword::WorksController
+      def show
+        # @collection_id = params[:collection_id]
+        find_work_by_query
+        render_not_found and return unless @object
+        @file_set_ids = file_set_ids
+
+        if (WillowSword.config.xml_mapping_read == 'MODS')
+          @mods = assign_model_to_mods
+          render '/willow_sword/v2/works/show.mods.xml.builder', formats: [:xml], status: 200
+        elsif (WillowSword.config.xml_mapping_read == 'Hyku')
+          render '/willow_sword/v2/works/show.hyku.xml.builder', formats: [:xml], status: 200
+        else
+          render '/willow_sword/v2/works/show.dc.xml.builder', formats: [:xml], status: 200
+        end
+      end
+    end
+  end
+end

--- a/app/views/willow_sword/v2/file_sets/show.xml.builder
+++ b/app/views/willow_sword/v2/file_sets/show.xml.builder
@@ -1,0 +1,67 @@
+if WillowSword.config.xml_mapping_read == 'Hyku'
+  # This use of HykuCrosswalk is very similar to the works/show.hyku.xml.builder
+  # however I couldn't figure out a way in the builder to render that one.  It would be
+  # Nice if we can just use the one builder in the future.
+  xw = WillowSword::HykuCrosswalk.new(@file_set)
+  xml.feed(xw.namespace_declarations) do
+    xml.title @file_set.title.join(", ")
+
+    xml.content(rel:"src", href:v2_file_sets_url(params[:collection_id], params[:work_id], @file_set))
+    xml.link(rel:"edit", href:v2_file_sets_url(params[:collection_id], params[:work_id], @file_set))
+
+    # Add h4csys, mainly system generated metadata
+    xw.system_terms.each do |term|
+      Array.wrap(@file_set.send(term)).each do |val|
+        val = val.to_s
+        next if val.blank?
+
+        prefix = xw.prefix_lookup_for('h4csys')
+        xml.tag!(:"#{prefix}:#{term}", val)
+      end
+    end
+
+    # Add h4cmeta, settable metadata
+    xw.terms.each do |term|
+      Array.wrap(@file_set.send(term)).each do |val|
+        val = val.to_s
+        next if val.blank?
+
+        prefix = xw.prefix_lookup_for('h4cmeta')
+        xml.tag!(:"#{prefix}:#{term}", val)
+      end
+    end
+
+    # Add dc and dcterms
+    xw.dc_terms.each do |term|
+      Array.wrap(@file_set.send(term)).each do |val|
+        val = val.to_s
+        next if val.blank?
+
+        prefix = xw.dc_terms_to_fallback_to_dc.include?(term) ? 'dc' : xw.prefix_lookup_for(term)
+        translated_term = xw.term_translation_mappings[term] || term
+        xml.tag!(:"#{prefix}:#{translated_term}", val)
+      end
+    end
+  end
+else
+  xml.feed(xmlns:"http://www.w3.org/2005/Atom",
+    'xmlns:dcterms':"http://purl.org/dc/terms/",
+    'xmlns:dc':"http://purl.org/dc/elements/1.1/") do
+    Array(@file_set.title).each do |t|
+      xml.title t
+    end
+    xml.content(rel:"src", href:v2_file_sets_url(params[:collection_id], params[:work_id], @file_set))
+    xml.link(rel:"edit", href:v2_file_sets_url(params[:collection_id], params[:work_id], @file_set))
+
+    # Add dc metadata
+    xw = WillowSword::DcCrosswalk.new(nil, @work_klass)
+    @file_set.attributes.each do |attr, values|
+      if xw.terms.include?(attr.to_s)
+        term = xw.translated_terms.key(attr.to_s).present? ? xw.translated_terms.key(attr.to_s) : attr.to_s
+        Array(values).each do |val|
+          xml.dc term.to_sym, val
+        end
+      end
+    end
+  end
+end

--- a/app/views/willow_sword/v2/works/show.hyku.xml.builder
+++ b/app/views/willow_sword/v2/works/show.hyku.xml.builder
@@ -1,0 +1,50 @@
+xw = WillowSword::HykuCrosswalk.new(@object)
+xml.feed(xw.namespace_declarations) do
+  xml.title @object.title.join(", ")
+  # Get work
+  xml.content(rel:"src", href: v2_work_url(@object))
+  # Add file to work
+  xml.link(rel:"edit", href: v2_file_sets_url(@object))
+  @file_set_ids.each do |file_set_id|
+    xml.entry do
+      # Get file metadata
+      xml.content(rel:"src", href: v2_file_set_url(file_set_id))
+      # Edit file metadata
+      xml.link(rel:"edit", href: v2_file_set_url(file_set_id))
+    end
+  end
+
+  # Add h4csys, mainly system generated metadata
+  xw.system_terms.each do |term|
+    Array.wrap(@object.send(term)).each do |val|
+      val = val.to_s
+      next if val.blank?
+
+      prefix = xw.prefix_lookup_for('h4csys')
+      xml.tag!(:"#{prefix}:#{term}", val)
+    end
+  end
+
+  # Add h4cmeta, settable metadata
+  xw.terms.each do |term|
+    Array.wrap(@object.send(term)).each do |val|
+      val = val.to_s
+      next if val.blank?
+
+      prefix = xw.prefix_lookup_for('h4cmeta')
+      xml.tag!(:"#{prefix}:#{term}", val)
+    end
+  end
+
+  # Add dc and dcterms
+  xw.dc_terms.each do |term|
+    Array.wrap(@object.send(term)).each do |val|
+      val = val.to_s
+      next if val.blank?
+
+      prefix = xw.dc_terms_to_fallback_to_dc.include?(term) ? 'dc' : xw.prefix_lookup_for(term)
+      translated_term = xw.term_translation_mappings[term] || term
+      xml.tag!(:"#{prefix}:#{translated_term}", val)
+    end
+  end
+end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -1,0 +1,7 @@
+Hyrax::Resource.delegate(
+  :visibility_during_embargo, :visibility_after_embargo, :embargo_release_date, to: :embargo, allow_nil: true
+)
+
+Hyrax::Resource.delegate(
+  :visibility_during_lease, :visibility_after_lease, :lease_expiration_date, to: :lease, allow_nil: true
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,10 @@ WillowSword::Engine.routes.draw do
       end
     end
 
+    namespace :v2 do
+      root to: 'service_documents#show'
+
+      resource :service_document, only: [:show]
+    end
   end
-
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ WillowSword::Engine.routes.draw do
       root to: 'service_documents#show'
 
       resource :service_document, only: [:show]
+      resources :collections, only: [:show]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ WillowSword::Engine.routes.draw do
 
       resource :service_document, only: [:show]
       resources :collections, only: [:show]
+      resources :works, only: [:show, :create, :update]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ WillowSword::Engine.routes.draw do
       resource :service_document, only: [:show]
       resources :collections, only: [:show]
       resources :works, only: [:show, :create, :update]
+      resources :file_sets, only: [:show, :create, :update]
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,8 +21,12 @@ require 'rspec/rails'
 if dockerized?
   require 'database_cleaner/active_record'
   require 'factory_bot'
+  require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'strategies', 'valkyrie_resource').to_s
   require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'users').to_s
+  require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'hyrax_collection').to_s
   require Hyrax::Engine.root.join('spec', 'support', 'fakes', 'test_hydra_group_service').to_s
+
+  FactoryBot.register_strategy(:valkyrie_create, ValkyrieCreateStrategy)
 end
 
 ENGINE_RAILS_ROOT = File.join(File.dirname(__FILE__), '../')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,7 +24,9 @@ if dockerized?
   require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'strategies', 'valkyrie_resource').to_s
   require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'users').to_s
   require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'hyrax_collection').to_s
+  require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'hyrax_work').to_s
   require Hyrax::Engine.root.join('spec', 'support', 'fakes', 'test_hydra_group_service').to_s
+  require Hyrax::Engine.root.join('spec', 'support', 'simple_work').to_s
 
   FactoryBot.register_strategy(:valkyrie_create, ValkyrieCreateStrategy)
 end
@@ -86,6 +88,7 @@ RSpec.configure do |config|
     config.use_transactional_fixtures = false
 
     config.before(:suite) do
+      WillowSword.config.xml_mapping_read = 'Hyku' # since we're primarily testing Hyku output
       DatabaseCleaner.allow_remote_database_url = true
       DatabaseCleaner.clean_with(:truncation)
       User.group_service = TestHydraGroupService.new

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,6 +25,7 @@ if dockerized?
   require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'users').to_s
   require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'hyrax_collection').to_s
   require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'hyrax_work').to_s
+  require Hyrax::Engine.root.join('lib', 'hyrax', 'specs', 'shared_specs', 'factories', 'hyrax_file_set').to_s
   require Hyrax::Engine.root.join('spec', 'support', 'fakes', 'test_hydra_group_service').to_s
   require Hyrax::Engine.root.join('spec', 'support', 'simple_work').to_s
 

--- a/spec/request/v2/collections_spec.rb
+++ b/spec/request/v2/collections_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe 'SWORD Collections', type: :request do
+  describe 'GET /sword/v2/collections/:id' do
+    before do
+      create(:admin, email: 'admin@example.com', api_key: 'test')
+      valkyrie_create(:hyrax_collection, id: 1, title: ['Test Collection'], description: ['A test collection'])
+    end
+
+    it 'returns 200 with valid API key' do
+      get '/sword/v2/collections/1', headers: { 'Api-key' => 'test' }
+
+      expect(response.status).to eq(200)
+      expect(response.content_type).to include('application/xml')
+      expect(response.body).to include('<feed')
+    end
+  end
+end

--- a/spec/request/v2/file_sets_spec.rb
+++ b/spec/request/v2/file_sets_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe 'SWORD FileSets', type: :request do
+  describe 'GET /sword/v2/file_sets/:id' do
+    before do
+      create(:admin, email: 'admin@example.com', api_key: 'test')
+      valkyrie_create(:hyrax_file_set, id: 1, title: ['Test File Set'])
+    end
+
+    it 'returns 200 with valid API key' do
+      get '/sword/v2/file_sets/1', headers: { 'Api-key' => 'test' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include('application/xml')
+      expect(response.body).to include('<feed')
+    end
+  end
+end

--- a/spec/request/v2/service_document_spec.rb
+++ b/spec/request/v2/service_document_spec.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe "SWORD Service Document", type: :request do
-  describe "GET /sword/service_document" do
+  describe "GET /sword/v2/service_document" do
     before do
       Hyrax::AdminSetCreateService.find_or_create_default_admin_set
       create(:admin, email: 'admin@example.com', api_key: 'test')
     end
 
     it "returns 200 with valid API key" do
-      get '/sword/service_document', headers: { 'Api-key' => 'test' }
+      get '/sword/v2/service_document', headers: { 'Api-key' => 'test' }
+
       expect(response.status).to eq(200)
       expect(response.content_type).to include('application/xml')
       expect(response.body).to include('<service')

--- a/spec/request/v2/works_spec.rb
+++ b/spec/request/v2/works_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe 'SWORD Works', type: :request do
+  describe 'GET /sword/v2/works/:id' do
+    before do
+      create(:admin, email: 'admin@example.com', api_key: 'test')
+      valkyrie_create(:monograph, id: 1, title: ['Test Work'], description: ['A test work'])
+    end
+
+    it 'returns 200 with valid API key' do
+      get '/sword/v2/works/1', headers: { 'Api-key' => 'test' }
+
+      expect(response.status).to eq(200)
+      expect(response.content_type).to include('application/xml')
+      expect(response.body).to include('<feed')
+    end
+  end
+end


### PR DESCRIPTION
## 🎁 Implement new V2 endpoints

14c1b482c6c4c276f0c7def57db992647715a3bd

This commit will introduce the V2 namespace for the SWORD API,
simplifying the endpoint structure starting with the service_document.

## 🎁 Add route for collections

3f2f83dec782d0538dc62097481d8d88c314917a

This commit will add a new route for collections which should reach
parity with legacy.

## 🎁 Add route for works

276d6e91177fcdb15d241a9f39f11f6c5c781f0c

This commit will add a new route for works which should reach parity
with the existing works route.  In the test it revealed some major
differences between Hyrax and Hyku that makes me want to spin up a Hyku
instance instead.  I think it should be fine for now but I will revisit
that idea when it becomes too painful.

## 🎁 Add route for file_sets

56c320f3241e7ec143b514e061af9fb7ce6d9e59

This commit will add a new route for file_sets.  Right now the route
does not reach parity with the legacy endpoint but that's because it's
okay because that part is going to be changing in the next leg of work.

Ref:
- https://github.com/notch8/willow_sword/pull/20