### PR TITLE
User permissions

### DIFF
--- a/app/controllers/concerns/willow_sword/authorize_request.rb
+++ b/app/controllers/concerns/willow_sword/authorize_request.rb
@@ -6,9 +6,10 @@ module WillowSword
       @current_user = nil
       return true unless WillowSword.config.authorize_request
       api_key = @headers.fetch(:api_key, nil)
-      @current_user = User.find_by(api_key: @headers[:api_key]) unless api_key.blank?
-      unless @current_user.present?
-        unless api_key.blank?
+      @current_user = User.find_by(api_key: api_key) if api_key.present?
+
+      if @current_user.blank?
+        if api_key.present?
           message = "Not authorized. API key not found."
         else
           message = "Not authorized. API key not available."

--- a/app/controllers/concerns/willow_sword/authorize_request.rb
+++ b/app/controllers/concerns/willow_sword/authorize_request.rb
@@ -5,20 +5,20 @@ module WillowSword
     def authorize_request
       @current_user = nil
       return true unless WillowSword.config.authorize_request
-      api_key = @headers.fetch(:api_key, nil)
-      @current_user = User.find_by(api_key: api_key) if api_key.present?
 
-      if @current_user.blank?
+      api_key = @headers.fetch(:api_key, nil)
+      message =
         if api_key.present?
-          message = "Not authorized. API key not found."
+          @current_user = User.find_by(api_key: api_key)
+          'Not authorized. API key not found.' # not used if user is allowed
         else
-          message = "Not authorized. API key not available."
+          'Not authorized. API key not available.'
         end
-        @error = WillowSword::Error.new(message, :target_owner_unknown)
-        render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
-      else
-        true
-      end
+
+      return true if allowed_access?
+
+      @error = WillowSword::Error.new(message, :target_owner_unknown)
+      render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
     end
 
     def validate_target_user
@@ -34,5 +34,8 @@ module WillowSword
       end
     end
 
+    def allowed_access?
+      @current_user.present? && @current_user.in?(::User.registered.without_system_accounts.for_repository.distinct)
+    end
   end
 end

--- a/app/controllers/concerns/willow_sword/handle_error.rb
+++ b/app/controllers/concerns/willow_sword/handle_error.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module WillowSword
+  module HandleError
+    extend ActiveSupport::Concern
+
+    included do
+      rescue_from CanCan::AccessDenied, StandardError, with: :handle_error
+    end
+
+    def handle_error(exception)
+      error_type = exception.is_a?(CanCan::AccessDenied) ? :target_owner_unknown : :default
+      @error = WillowSword::Error.new(exception.message, error_type)
+      render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
+    end
+  end
+end

--- a/app/controllers/willow_sword/v2/file_sets_controller.rb
+++ b/app/controllers/willow_sword/v2/file_sets_controller.rb
@@ -3,46 +3,59 @@
 module WillowSword
   module V2
     class FileSetsController < WillowSword::FileSetsController
-      def show
-        @file_set = find_file_set
-        render_file_set_not_found and return unless @file_set
+      include WillowSword::HandleError
 
-        xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
-        render 'entry.hyku.xml.builder', locals: { xw: xw }, formats: [:xml], status: :ok
-      end
+      before_action :find_object_or_render_not_found, only: [:create, :show, :update]
+      before_action :authorize_action, only: [:create, :show, :update]
 
       def create
-        find_work_by_query(params[:work_id])
-        render_work_not_found and return unless @object
-        @error = nil
-        if perform_create
-          xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
-          render 'entry.hyku.xml.builder', locals: { xw: xw }, formats: [:xml], status: :created, location: v2_file_set_url(@file_set)
-        else
-          @error = WillowSword::Error.new("Error creating file set") unless @error.present?
-          render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
-        end
+        perform_create
+
+        xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
+        render 'entry.hyku.xml.builder', locals: { xw: xw }, status: :created
+      end
+
+      def show
+        xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
+        render 'entry.hyku.xml.builder', locals: { xw: xw }, status: :ok
       end
 
       def update
-        @file_set = find_file_set
-        render_file_set_not_found and return unless @file_set
+        perform_update
 
-        if perform_update
-          xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
-          render 'entry.hyku.xml.builder', locals: { xw: xw }, formats: [:xml], status: :ok
-        else
-          @error = WillowSword::Error.new("Error updating file set") unless @error.present?
-          render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
-        end
+        xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
+        render 'entry.hyku.xml.builder', locals: { xw: xw }, status: :ok
       end
 
+      private
+
       def extract_metadata(file_path)
-        @attributes = {}
         xw = WillowSword::V2::HykuCrosswalk.new(file_path, Hyrax.config.file_set_model.constantize)
         xw.map_xml
         @attributes = xw.metadata
         set_visibility
+      end
+
+      def find_object_or_render_not_found
+        case action_name
+        when 'create'
+          find_work_by_query(params[:work_id])
+          render_work_not_found if @object.nil?
+        when 'show', 'update'
+          @file_set = find_file_set
+          render_file_set_not_found if @file_set.nil?
+        end
+      end
+
+      def authorize_action
+        case action_name
+        when 'create'
+          authorize! :create, @object
+        when 'show'
+          authorize! :read, @file_set
+        when 'update'
+          authorize! :edit, @file_set
+        end
       end
     end
   end

--- a/app/controllers/willow_sword/v2/works_controller.rb
+++ b/app/controllers/willow_sword/v2/works_controller.rb
@@ -3,65 +3,72 @@
 module WillowSword
   module V2
     class WorksController < WillowSword::WorksController
+      before_action :find_object_or_render_not_found, only: [:show, :update]
+      before_action :authorize_action, only: [:create, :show, :update]
+      rescue_from CanCan::AccessDenied, StandardError, with: :handle_error
+
       def create
-        @error = nil
-
-        begin
-          perform_create
-          @file_set_ids = file_set_ids
-          @child_work_ids = child_work_ids
-
-          xw = WillowSword::V2::HykuCrosswalk.new(nil, @object)
-          render 'entry.hyku.xml.builder', locals: { xw: xw }, status: :created, location: v2_work_url(@object.id)
-        rescue StandardError => e
-          @error = WillowSword::Error.new(e.message) unless @error.present?
-          render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
-        end
-      end
-
-      def show
-        find_work_by_query
-        render_not_found and return unless @object
+        perform_create
         @file_set_ids = file_set_ids
         @child_work_ids = child_work_ids
 
         xw = WillowSword::V2::HykuCrosswalk.new(nil, @object)
-        render '/willow_sword/v2/works/entry.hyku.xml.builder', locals: { xw: xw }, status: 200
+        render 'entry.hyku.xml.builder', locals: { xw: xw }, status: :created
+      end
+
+      def show
+        @file_set_ids = file_set_ids
+        @child_work_ids = child_work_ids
+
+        xw = WillowSword::V2::HykuCrosswalk.new(nil, @object)
+        render 'entry.hyku.xml.builder', locals: { xw: xw }, status: :ok
       end
 
       def update
-        find_work_by_query
-        render_not_found and return unless @object
-        @error = nil
+        perform_update
+        @file_set_ids = file_set_ids
+        @child_work_ids = child_work_ids
 
-        begin
-          perform_update
-          @file_set_ids = file_set_ids
-          @child_work_ids = child_work_ids
-
-          xw = WillowSword::V2::HykuCrosswalk.new(nil, @object)
-          render 'entry.hyku.xml.builder', locals: { xw: xw }, status: :ok
-        rescue StandardError => e
-          @error = WillowSword::Error.new(e.message) unless @error.present?
-          render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
-        end
+        xw = WillowSword::V2::HykuCrosswalk.new(nil, @object)
+        render 'entry.hyku.xml.builder', locals: { xw: xw }, status: :ok
       end
+
+      private
 
       def extract_metadata(file_path)
         xw = WillowSword::V2::HykuCrosswalk.new(file_path, @work_klass)
         xw.map_xml
         @attributes = xw.metadata
         set_visibility
-        @resource_type = xw.model if @attributes.any?
       end
-
-      private
 
       def child_work_ids
         member_ids = @object&.member_ids || []
         return [] if member_ids.empty?
 
         Hyrax.query_service.find_many_by_ids(ids: member_ids).filter_map { |member| member.id if member.work? }
+      end
+
+      def find_object_or_render_not_found
+        find_work_by_query
+        render_not_found if @object.nil?
+      end
+
+      def authorize_action
+        case action_name
+        when 'create'
+          authorize! :create, @work_klass
+        when 'show'
+          authorize! :read, @object
+        when 'update'
+          authorize! :edit, @object
+        end
+      end
+
+      def handle_error(exception)
+        error_type = exception.is_a?(CanCan::AccessDenied) ? :target_owner_unknown : :default
+        @error = WillowSword::Error.new(exception.message, error_type)
+        render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
       end
     end
   end

--- a/app/controllers/willow_sword/v2/works_controller.rb
+++ b/app/controllers/willow_sword/v2/works_controller.rb
@@ -3,9 +3,10 @@
 module WillowSword
   module V2
     class WorksController < WillowSword::WorksController
+      include WillowSword::HandleError
+
       before_action :find_object_or_render_not_found, only: [:show, :update]
       before_action :authorize_action, only: [:create, :show, :update]
-      rescue_from CanCan::AccessDenied, StandardError, with: :handle_error
 
       def create
         perform_create
@@ -63,12 +64,6 @@ module WillowSword
         when 'update'
           authorize! :edit, @object
         end
-      end
-
-      def handle_error(exception)
-        error_type = exception.is_a?(CanCan::AccessDenied) ? :target_owner_unknown : :default
-        @error = WillowSword::Error.new(exception.message, error_type)
-        render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -101,6 +101,10 @@ RSpec.configure do |config|
     config.before(:each) do
       DatabaseCleaner.strategy = :transaction
       DatabaseCleaner.start
+
+      # mocking .for_repository scope for Hyku applications
+      users_relation = User.registered.without_system_accounts
+      allow(User).to receive_message_chain(:registered, :without_system_accounts, :for_repository).and_return(users_relation)
     end
 
     config.append_after(:each) do

--- a/spec/request/v2/service_document_spec.rb
+++ b/spec/request/v2/service_document_spec.rb
@@ -3,28 +3,62 @@
 RSpec.describe 'SWORD Service Document', type: :request do
   describe 'GET /sword/v2/service_document' do
     before do
-      Hyrax::AdminSetCreateService.find_or_create_default_admin_set
       create(:admin, email: 'admin@example.com', api_key: 'test')
     end
 
     let(:doc) { Nokogiri::XML(response.body) }
 
-    it 'returns XML with no errors' do
-      get '/sword/v2/service_document', headers: { 'Api-key' => 'test' }
+    context 'when there is an admin set' do
+      before do
+        Hyrax::AdminSetCreateService.find_or_create_default_admin_set
+      end
 
-      expect(response).to have_http_status(:ok)
-      expect(doc.errors).to be_empty
-      expect(doc.root.namespaces).to eq(
-        {
-          'xmlns:atom' => 'http://www.w3.org/2005/Atom',
-          'xmlns:dcterms' => 'http://purl.org/dc/terms/',
-          'xmlns:sword' => 'http://purl.org/net/sword/terms/',
-          'xmlns:h4csys' => 'https://hykucommons.org/schema/system',
-          'xmlns' => 'http://www.w3.org/2007/app'
-        }
-      )
-      expect(doc.root.xpath('//h4csys:type', 'h4csys' => 'https://hykucommons.org/schema/system')).to be_one
-      expect(doc.xpath('//*[local-name()="collection"]').first['href']).to include('/sword/v2/collections/')
+      context 'with valid API key' do
+        it 'returns XML with no errors' do
+          get '/sword/v2/service_document', headers: { 'Api-key' => 'test' }
+
+          expect(response).to have_http_status(:ok)
+          expect(doc.errors).to be_empty
+          expect(doc.root.namespaces).to eq(
+            {
+              'xmlns:atom' => 'http://www.w3.org/2005/Atom',
+              'xmlns:dcterms' => 'http://purl.org/dc/terms/',
+              'xmlns:sword' => 'http://purl.org/net/sword/terms/',
+              'xmlns:h4csys' => 'https://hykucommons.org/schema/system',
+              'xmlns' => 'http://www.w3.org/2007/app'
+            }
+          )
+          expect(doc.root.xpath('//h4csys:type', 'h4csys' => 'https://hykucommons.org/schema/system')).to be_one
+          expect(doc.xpath('//*[local-name()="collection"]').first['href']).to include('/sword/v2/collections/')
+        end
+      end
+
+      context 'with invalid API key' do
+        it 'returns 403 Forbidden' do
+          get '/sword/v2/service_document', headers: { 'Api-key' => 'invalid' }
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'with no API key' do
+        it 'returns 403 Forbidden' do
+          get '/sword/v2/service_document'
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+    context 'when there are no admin sets' do
+      context 'with valid API key' do
+        it 'returns XML with errors' do
+          get '/sword/v2/service_document', headers: { 'Api-key' => 'test' }
+
+          expect(response).to have_http_status(:forbidden)
+          expect(doc.errors).to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## 🐛 Fix service document for certain users

d95032477e6e903982349574280d688b01185242

Previously, when a user that does not have accessible Admin Sets or
User Collections, the service document would fall apart.  Now it will
error out gracefully and return a response with a 403 (forbidden).

## 🎁 Check if user is in the tenant

fb1688a56ce2d6b360846c3640d85ad8d74ca047

This commit will refactor the authorize_request method and also do an
additional check to see if the user is in the tenant.  This is a very
Hyku centric concept so if we ever want to make this gem work for Hyrax
we would need to rework the #allowed_access? method and override it in
Hyku to add the .for_repository scope.

## 🎁 Add proper authorization for work actions

567675cf044aafa6ffb8cc4badebb2696ca6df84

This commit will refactor the v2 works controller to include
authorization checks for create, show, and update actions using
CanCanCan.

## 🎁 Add proper authorization for file set actions

21dd01848700ccf14e0118376e9993d5ca1cd17b

This commit will refactor the v2 file sets controller to include
authorization checks for create, show, and update actions using CanCanCan
much like the v2 works controller.  The error handling was also extracted
into a concern for reuse.
