### PR TITLE
🎁 Add check for On-Behalf-Of header

### DIFF
--- a/spec/request/v2/file_sets_spec.rb
+++ b/spec/request/v2/file_sets_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe 'SWORD FileSets', type: :request do
         'Content-Disposition' => 'attachment; filename=sample-file.pdf',
         'Content-Type' => 'text/plain',
         'In-Progress' => 'false',
-        'On-Behalf-Of' => 'admin@example.com',
         'Api-key' => 'test'
       }
     end
@@ -62,7 +61,6 @@ RSpec.describe 'SWORD FileSets', type: :request do
           'Content-Disposition' => 'attachment; filename=fileSetTestPackage.zip',
           'Content-Type' => 'application/zip',
           'In-Progress' => 'false',
-          'On-Behalf-Of' => 'admin@example.com',
           'Api-key' => 'test'
         }
 
@@ -88,8 +86,7 @@ RSpec.describe 'SWORD FileSets', type: :request do
       {
         'Content-Type' => 'application/xml',
         'In-Progress' => 'false',
-        'On-Behalf-Of' => 'admin@example.com',
-        'Api-key' => 'test',
+        'Api-key' => 'test'
       }
     end
     let(:params) do

--- a/spec/request/v2/works_spec.rb
+++ b/spec/request/v2/works_spec.rb
@@ -55,9 +55,8 @@ RSpec.describe 'SWORD Works', type: :request do
             'Content-Disposition' => 'attachment; filename=metadata.xml',
             'Content-Type' => 'application/xml',
             'In-Progress' => 'false',
-            'On-Behalf-Of' => 'admin@example.com',
             'Packaging' => 'application/atom+xml;type=entry',
-            'Api-key' => 'test',
+            'Api-key' => 'test'
           }
         end
         let(:params) do
@@ -159,8 +158,7 @@ RSpec.describe 'SWORD Works', type: :request do
       let(:headers) do
         {
           'In-Progress' => 'false',
-          'On-Behalf-Of' => 'admin@example.com',
-          'Api-key' => 'test',
+          'Api-key' => 'test'
         }
       end
       let(:xml_file) do
@@ -187,8 +185,7 @@ RSpec.describe 'SWORD Works', type: :request do
             'Content-Disposition' => 'attachment; filename=testPackage.zip',
             'Content-Type' => 'application/zip',
             'In-Progress' => 'false',
-            'On-Behalf-Of' => 'admin@example.com',
-            'Api-key' => 'test',
+            'Api-key' => 'test'
           }
         end
         let(:params) do
@@ -260,8 +257,7 @@ RSpec.describe 'SWORD Works', type: :request do
       {
         'Content-Type' => 'application/xml',
         'In-Progress' => 'false',
-        'On-Behalf-Of' => 'admin@example.com',
-        'Api-key' => 'test',
+        'Api-key' => 'test'
       }
     end
     let(:params) do


### PR DESCRIPTION
This commit will add a check to see if the user is allowed to use the On-Behalf-Of header to act on behalf of another user.  If the user can manage other users then they can use the On-Behalf-Of header.