### PR TITLE
🐛 Admin Set returns works

### DIFF
--- a/app/helpers/willow_sword/application_helper.rb
+++ b/app/helpers/willow_sword/application_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module WillowSword
+  module ApplicationHelper
+    def work_url_for(work_object)
+      if work_object.is_a?(SolrDocument)
+        model_name = extract_model_name(work_object)
+        work_id = work_object['id'] || work_object.id
+        build_work_url(model_name, work_id)
+      else
+        Rails.application.routes.url_helpers.polymorphic_url(work_object, host: request.host_with_port)
+      end
+    end
+
+    private
+
+    def extract_model_name(work_object)
+      work_object['human_readable_type_tesim'].first.parameterize(separator: '_').pluralize
+    end
+
+    def build_work_url(model_name, work_id)
+      "#{request.protocol}#{request.host_with_port}/concern/#{model_name}/#{work_id}"
+    end
+  end
+end

--- a/app/views/willow_sword/v2/collections/show.xml.builder
+++ b/app/views/willow_sword/v2/collections/show.xml.builder
@@ -5,10 +5,20 @@ xml.feed(xmlns:"http://www.w3.org/2005/Atom", 'xmlns:h4csys':"https://hykucommon
   xml.link(rel:"edit", href:v2_collection_url(@collection.id))
   @works.each do |work|
     xml.entry do
-      xml.content(rel:"src", href:v2_work_url(work.id))
+      xml.id work.id
+      xml.title work.title.join(', ')
+      work.creator.each do |creator|
+        xml.author do
+          xml.name creator
+        end
+      end
+      xml.updated(work['date_modified_dtsi'])
+      xml.content(src: work_url_for(work), type: 'text/html')
       work['member_ids_ssim']&.each do |fs_id|
         xml.link(rel:"edit", href:v2_file_set_url(fs_id))
       end
+      # assumes *_tesim
+      xml.summary(work['description_tesim']&.join(', ') || work['abstract_tesim']&.join(', '))
     end
   end
 end

--- a/app/views/willow_sword/v2/works/entry.hyku.xml.builder
+++ b/app/views/willow_sword/v2/works/entry.hyku.xml.builder
@@ -1,9 +1,15 @@
 xml.entry(xw.namespace_declarations) do
   xml.id @object.id
   xml.title @object.title.join(', ')
-  xml.content(src: Rails.application.routes.url_helpers.polymorphic_url(@object, host: request.host_with_port),
-              type: 'text/html')
+  @object.creator.map do |creator|
+    xml.author do
+      xml.name creator
+    end
+  end
+  xml.updated @object.updated_at.to_s
+  xml.content(src: work_url_for(@object), type: 'text/html')
   xml.link(rel: 'edit', href: v2_work_url(@object))
+  xml.summary @object.try(:description)&.join(', ') || @object.try(:abstract)&.join(', ')
 
   @file_set_ids&.each do |file_set_id|
     xml.link(rel: 'edit-media', href: v2_file_set_url(file_set_id))

--- a/spec/request/v2/collections_spec.rb
+++ b/spec/request/v2/collections_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe 'SWORD Collections', type: :request do
   describe 'GET /sword/v2/collections/:id' do
     let(:id) { 'collection_1' }
+    let(:admin_set_id) { Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id }
 
     before do
       create(:admin, email: 'admin@example.com', api_key: 'test')
@@ -14,8 +15,8 @@ RSpec.describe 'SWORD Collections', type: :request do
       Hyrax.index_adapter.save(resource: collection)
     end
 
-    let!(:work) { valkyrie_create(:hyrax_work, :with_one_file_set, id: 'work_1', title: ['Test Work']) }
-    let!(:collection) { valkyrie_create(:hyrax_collection, id: id, title: ['Test Collection'], description: ['A test collection']) }
+    let(:work) { valkyrie_create(:monograph, :with_one_file_set, id: 'work_1', title: ['Test Work'], description: ['A description'], creator: ['A Creator'], admin_set_id: admin_set_id) }
+    let(:collection) { valkyrie_create(:hyrax_collection, id: id, title: ['Test Collection'], description: ['A test collection']) }
 
     it 'returns XML with no errors' do
       get "/sword/v2/collections/#{id}", headers: { 'Api-key' => 'test' }
@@ -29,10 +30,33 @@ RSpec.describe 'SWORD Collections', type: :request do
       expect(doc.root.xpath('h4csys:type', 'h4csys' => 'https://hykucommons.org/schema/system')).to be_one
       expect(doc.root.xpath('atom:link', 'atom' => 'http://www.w3.org/2005/Atom').first['href'])
         .to include("/sword/v2/collections/#{collection.id}")
-      expect(doc.root.xpath('atom:entry/atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['href'])
-        .to include("/sword/v2/works/#{work.id}")
+      expect(doc.root.xpath('atom:entry/atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['src'])
+        .to include("/concern/monographs/#{work.id}")
+      expect(doc.root.xpath('atom:entry/atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['type'])
+        .to eq('text/html')
       expect(doc.root.xpath('atom:entry/atom:link', 'atom' => 'http://www.w3.org/2005/Atom').first['href'])
         .to include("/sword/v2/file_sets/#{work.member_ids.first}")
+      expect(doc.root.xpath('atom:entry/atom:summary', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq('A description')
+    end
+
+    context 'when the id is an admin set' do
+      it 'still returns work entries' do
+        get "/sword/v2/collections/#{admin_set_id}", headers: { 'Api-key' => 'test' }
+
+        doc = Nokogiri::XML(response.body)
+        expect(doc.errors).to be_empty
+        expect(doc.root.xpath('atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq(admin_set_id)
+        expect(doc.root.xpath('h4csys:type', 'h4csys' => 'https://hykucommons.org/schema/system')).to be_one
+        expect(doc.root.xpath('atom:link', 'atom' => 'http://www.w3.org/2005/Atom').first['href'])
+          .to include("/sword/v2/collections/#{admin_set_id}")
+        expect(doc.root.xpath('atom:entry/atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['src'])
+          .to include("/concern/monographs/#{work.id}")
+        expect(doc.root.xpath('atom:entry/atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['type'])
+          .to eq('text/html')
+        expect(doc.root.xpath('atom:entry/atom:link', 'atom' => 'http://www.w3.org/2005/Atom').first['href'])
+          .to include("/sword/v2/file_sets/#{work.member_ids.first}")
+        expect(doc.root.xpath('atom:entry/atom:summary', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq('A description')
+      end
     end
   end
 end

--- a/spec/request/v2/works_spec.rb
+++ b/spec/request/v2/works_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'SWORD Works', type: :request do
 
   describe 'GET /sword/v2/works/:id' do
     before do
-      valkyrie_create(:monograph, id: 'child-work-123', title: ['Child Work'], description: ['A child work'])
-      parent_work = valkyrie_create(:monograph, :with_one_file_set, id: 'work-123', title: ['Test Work'], description: ['A test work'])
+      valkyrie_create(:monograph, id: 'child-work-123', title: ['Child Work'], description: ['A child work'], creator: ['A Creator'])
+      parent_work = valkyrie_create(:monograph, :with_one_file_set, id: 'work-123', title: ['Test Work'], description: ['A test work'], creator: ['A Creator'])
       parent_work.member_ids << 'child-work-123'
       Hyrax.persister.save(resource: parent_work)
       Hyrax.index_adapter.save(resource: parent_work)
@@ -23,6 +23,9 @@ RSpec.describe 'SWORD Works', type: :request do
       expect(doc.root.xpath('atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq('work-123')
       expect(doc.root.xpath('atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['src']).to end_with('/concern/monographs/work-123')
       expect(doc.root.xpath('atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['type']).to eq('text/html')
+      expect(doc.root.xpath('atom:author/atom:name', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq('A Creator')
+      expect(doc.root.xpath('atom:updated', 'atom' => 'http://www.w3.org/2005/Atom').text).to be_present
+      expect(doc.root.xpath('atom:summary', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq('A test work')
 
       work_link_element = doc.root.xpath('atom:link', 'atom' => 'http://www.w3.org/2005/Atom').find { |e| e['href'].include?('works') }
       expect(work_link_element['href']).to end_with("/sword/v2/works/work-123")


### PR DESCRIPTION
This commit will make the admin set return its works just like how a user collection does.  This will apply to both legacy and V2 endpoints. Also, added more required atom elements in the response; atom:summary, atom:updated, atom:author/name.