### PR TITLE
🧹 Work and file sets show properly in feed

### DIFF
--- a/app/views/willow_sword/v2/collections/show.xml.builder
+++ b/app/views/willow_sword/v2/collections/show.xml.builder
@@ -14,8 +14,9 @@ xml.feed(xmlns:"http://www.w3.org/2005/Atom", 'xmlns:h4csys':"https://hykucommon
       end
       xml.updated(work['date_modified_dtsi'])
       xml.content(src: work_url_for(work), type: 'text/html')
+      xml.link(rel: 'edit', href: v2_work_url(work.id))
       work['member_ids_ssim']&.each do |fs_id|
-        xml.link(rel:"edit", href:v2_file_set_url(fs_id))
+        xml.link(rel: 'edit-media', href: v2_file_set_url(fs_id))
       end
       # assumes *_tesim
       xml.summary(work['description_tesim']&.join(', ') || work['abstract_tesim']&.join(', '))

--- a/spec/request/v2/collections_spec.rb
+++ b/spec/request/v2/collections_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe 'SWORD Collections', type: :request do
         .to include("/concern/monographs/#{work.id}")
       expect(doc.root.xpath('atom:entry/atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['type'])
         .to eq('text/html')
-      expect(doc.root.xpath('atom:entry/atom:link', 'atom' => 'http://www.w3.org/2005/Atom').first['href'])
+      expect(doc.root.xpath('atom:entry/atom:link[@rel="edit"]', 'atom' => 'http://www.w3.org/2005/Atom').first['href'])
+        .to include("/sword/v2/works/#{work.id}")
+      expect(doc.root.xpath('atom:entry/atom:link[@rel="edit-media"]', 'atom' => 'http://www.w3.org/2005/Atom').last['href'])
         .to include("/sword/v2/file_sets/#{work.member_ids.first}")
       expect(doc.root.xpath('atom:entry/atom:summary', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq('A description')
     end
@@ -53,7 +55,9 @@ RSpec.describe 'SWORD Collections', type: :request do
           .to include("/concern/monographs/#{work.id}")
         expect(doc.root.xpath('atom:entry/atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['type'])
           .to eq('text/html')
-        expect(doc.root.xpath('atom:entry/atom:link', 'atom' => 'http://www.w3.org/2005/Atom').first['href'])
+        expect(doc.root.xpath('atom:entry/atom:link[@rel="edit"]', 'atom' => 'http://www.w3.org/2005/Atom').first['href'])
+          .to include("/sword/v2/works/#{work.id}")
+        expect(doc.root.xpath('atom:entry/atom:link[@rel="edit-media"]', 'atom' => 'http://www.w3.org/2005/Atom').last['href'])
           .to include("/sword/v2/file_sets/#{work.member_ids.first}")
         expect(doc.root.xpath('atom:entry/atom:summary', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq('A description')
       end


### PR DESCRIPTION
This commit will add the work's SWORD url to the collection feed and also make sure its file sets are marked 'edit-media'.