### PR TITLE
🐛 Fix unzip freezing on large files

### DIFF
--- a/lib/willow_sword/zip_package.rb
+++ b/lib/willow_sword/zip_package.rb
@@ -15,13 +15,16 @@ module WillowSword
 
     # Unpack a zip file along with any folders and sub folders at the destination
     def unzip_file
-      Zip::File.open(@src) { |zip_file|
-        zip_file.each { |f|
-          f_path=File.join(@dst, f.name)
-          FileUtils.mkdir_p(File.dirname(f_path))
-          zip_file.extract(f, f_path) unless File.exist?(f_path)
-        }
-      }
+      FileUtils.mkdir_p(@dst)
+      Rails.logger.info "Extracting #{File.basename(@src)} to #{@dst}"
+      cmd = ["unzip", "-q", @src, "-d", @dst]
+
+      unless system(*cmd)
+        error_msg = "Unzip failed with exit code #{$?.exitstatus}"
+        Rails.logger.error error_msg
+        @error = WillowSword::Error.new(error_msg, :unprocessable_entity)
+        return false
+      end
     end
 
     # Recursively generate a zip file from the contents of a specified directory.


### PR DESCRIPTION
Tested on a 2 gig file that was compressed to 1.2 gigs.  The ruby zip library was freezing so this commit will opt to use the system unzip command instead.