### PR TITLE
🐛 Fix file set metadata not working

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -55,7 +55,7 @@ Rails.application.config.to_prepare do
       def file_set_args(file, file_set_params = {})
         extra_params = file_set_extra_params(file)
         safe_params = extra_params.slice(*Hyrax::FileSet.user_settable_attributes)
-        super(file).merge(safe_params)
+        super(file, file_set_params).merge(safe_params)
       end
     end
 


### PR DESCRIPTION
The interface for setting extra metadata on file sets was changed in https://github.com/samvera/hyrax/pull/7228 so this commit will update the implementation to match.