### PR TITLE
Hyku7 bugs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require rails_helper
+--order random

--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -66,7 +66,7 @@ module Integrator
           ::Hyrax::Actors::LeaseActor.new(@object).destroy if @object.lease
         end
 
-        perform_transaction_for(object: @object, attrs: update_attributes) do
+        @object = perform_transaction_for(object: @object, attrs: update_attributes) do
           transactions["change_set.update_work"]
             .with_step_args(
               'work_resource.add_file_sets' => { uploaded_files: uploaded_files },

--- a/app/controllers/concerns/willow_sword/process_request.rb
+++ b/app/controllers/concerns/willow_sword/process_request.rb
@@ -11,7 +11,7 @@ module WillowSword
       # Choose based on content type
       return false unless validate_target_user
       case request.content_type
-      when 'multipart/form-data'
+      when /\Amultipart\/form-data/
         # multipart deposit
         return false unless validate_multi_part
         return false unless save_multipart_data

--- a/lib/willow_sword/v2/hyku_crosswalk.rb
+++ b/lib/willow_sword/v2/hyku_crosswalk.rb
@@ -144,10 +144,13 @@ module WillowSword
           end
 
           doc.remove_namespaces!
+          dc_alias = translated_terms.invert
           terms.each do |term|
             values = []
-            doc.xpath("//#{term}").each do |t|
-              values << t.text if t.text.present?
+            ([term] + Array.wrap(dc_alias[term])).each do |xpath_term|
+              doc.xpath("//#{xpath_term}").each do |t|
+                values << t.text if t.text.present?
+              end
             end
             key = translated_terms.include?(term) ? translated_terms[term] : term
             values = values.first if values.present? && singular.include?(term)

--- a/spec/controllers/concerns/willow_sword/process_request_spec.rb
+++ b/spec/controllers/concerns/willow_sword/process_request_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WillowSword::V2::WorksController, type: :controller do
+  describe '#validate_and_save_request' do
+    before do
+      allow(controller).to receive(:validate_target_user).and_return(true)
+      allow(controller).to receive(:bag_request)
+      allow(controller).to receive(:save_multipart_data).and_return(true)
+      allow(controller).to receive(:validate_multi_part).and_return(true)
+      allow(controller).to receive(:save_binary_data).and_return(true)
+      allow(controller).to receive(:validate_binary_deposit).and_return(true)
+      controller.instance_variable_set(:@file, nil)
+    end
+
+    # Regression: real HTTP clients include the boundary in the Content-Type header,
+    # e.g. "multipart/form-data; boundary=abc123". A string comparison
+    # (when 'multipart/form-data') fails to match and falls through to the binary
+    # deposit handler. The case statement must use a regex to match the MIME type prefix.
+    it 'routes multipart/form-data with boundary parameter to save_multipart_data, not save_binary_data' do
+      allow(controller.request).to receive(:content_type).and_return('multipart/form-data; boundary=a3d150d2cbc2ce26393d26ab9560712e')
+
+      expect(controller).to receive(:save_multipart_data).and_return(true)
+      expect(controller).not_to receive(:save_binary_data)
+
+      controller.validate_and_save_request
+    end
+  end
+end

--- a/spec/fixtures/v2/dc_metadata.xml
+++ b/spec/fixtures/v2/dc_metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dc xmlns="http://purl.org/dc/elements/1.1/">
+  <title>Minimal DC Metadata</title>
+  <creator>Test Creator</creator>
+  <type>Text</type>
+  <rights>http://rightsstatements.org/vocab/InC/1.0/</rights>
+  <record_info>dc regression test</record_info>
+</dc>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,7 +86,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   if dockerized?
-    config.filter_run_including type: :request # only run request specs in docker
+    config.filter_run_including type: ->(v) { %i[request controller].include?(v) } # only run request/controller specs in docker
 
     config.include FactoryBot::Syntax::Methods
     config.use_transactional_fixtures = false

--- a/spec/request/v2/works_spec.rb
+++ b/spec/request/v2/works_spec.rb
@@ -325,6 +325,7 @@ RSpec.describe 'SWORD Works', type: :request do
   end
 
   describe 'PUT /sword/v2/works/:id' do
+    include ActiveSupport::Testing::TimeHelpers
     let(:work) { valkyrie_create(:monograph, title: ['Original Title'], creator: ['Original Creator'], record_info: ['Some info']) }
     let(:headers) do
       {
@@ -342,15 +343,23 @@ RSpec.describe 'SWORD Works', type: :request do
     end
 
     it 'updates the work' do
-      put "/sword/v2/works/#{work.id}", headers: headers, params: params
+      original_updated_at = work.updated_at
 
-      doc = Nokogiri::XML(response.body)
+      # Advance time by 1 second so the update lands in a different second than creation.
+      # The XML serializes updated_at with second granularity, so without this the
+      # parsed timestamp can be <= original_updated_at when both happen in the same second.
+      travel_to 1.second.from_now do
+        put "/sword/v2/works/#{work.id}", headers: headers, params: params
 
-      expect(doc.root.name).to eq('entry')
-      expect(doc.root.xpath('atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq(work.id.to_s)
-      expect(doc.root.xpath('atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['src']).to end_with("/concern/monographs/#{work.id.to_s}")
-      expect(doc.root.xpath('atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['type']).to eq('text/html')
-      expect(doc.root.xpath('atom:title', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq('Updated Work Title')
+        doc = Nokogiri::XML(response.body)
+
+        expect(doc.root.name).to eq('entry')
+        expect(doc.root.xpath('atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq(work.id.to_s)
+        expect(doc.root.xpath('atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['src']).to end_with("/concern/monographs/#{work.id.to_s}")
+        expect(doc.root.xpath('atom:content', 'atom' => 'http://www.w3.org/2005/Atom').first['type']).to eq('text/html')
+        expect(doc.root.xpath('atom:title', 'atom' => 'http://www.w3.org/2005/Atom').text).to eq('Updated Work Title')
+        expect(Time.parse(doc.root.xpath('atom:updated', 'atom' => 'http://www.w3.org/2005/Atom').text)).to be > original_updated_at
+      end
     end
 
     context 'with a malformed XML' do

--- a/spec/request/v2/works_spec.rb
+++ b/spec/request/v2/works_spec.rb
@@ -154,6 +154,26 @@ RSpec.describe 'SWORD Works', type: :request do
             end
           end
         end
+
+        context 'with DC element names (<rights>, <type>) instead of Hyrax field names' do
+          let(:params) do
+            File.read(WillowSword::Engine.root.join('spec', 'fixtures', 'v2', 'dc_metadata.xml'))
+          end
+
+          it 'maps DC elements to work attributes' do
+            headers['Hyrax-Work-Model'] = 'Monograph'
+
+            post "/sword/v2/collections/#{admin_set_id}/works", headers: headers, params: params
+
+            expect(response).to have_http_status(:created)
+
+            id = Nokogiri::XML(response.body).root.xpath('atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text
+            work = Hyrax.query_service.find_by(id: id)
+
+            expect(work.resource_type).to eq(['Text'])
+            expect(work.rights_statement).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## 🐛 Fix stale work object

5a5b52534da64440e60e27e6ea9f8c383f2a4212

When the work is updated the old metadata is returned in the feed.  This
commit fetch the updated work and return the current metadata.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/578

## 🐛 Fix missing values validation for Hyku 7

1a1a4a9d34d24925cb811a20b024d143364e90d2

HykuCrosswalk.map_xml iterates over Hyrax schema field names (e.g.
rights_statement, resource_type) and searches the XML for those exact
element names.  DC submissions use the original DC element names
(<rights>, <type>).  The translated_terms hash had the right mappings
but was only checked in the output direction.  The fix adds a reverse
lookup (dc_alias) so that when searching the XML for rights_statement,
it also checks for <rights>, and for resource_type also checks <type>.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/579

## 🐛 Fix multipart form case

32820e4bd54d0a94b494ce0be99acfe6c4fddda2

Previously, the multipart form case was too strict, and would fail if
the content type had additional parameters, such as a boundary. This
commit relaxes the check to allow for additional parameters.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/580
